### PR TITLE
Add Accept header to http requests

### DIFF
--- a/go/HttpChecker.go
+++ b/go/HttpChecker.go
@@ -209,7 +209,18 @@ func (self *HttpChecker) LoadFingerprints() (err error) {
 // GetHttp performs an HTTP/HTTPS request to a URL and returns the content and
 // any error.
 func GetHttp(url string) (content []byte, err error) {
-	resp, err := http.Get(url)
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		logger.Infof("New Request error on %s: %s\n", url, err)
+	}
+
+	// Add Accept header for greater compatibility with some servers
+	req.Header = http.Header{
+		"Accept": {"*/*"},
+	}
+
+	client := http.Client{}
+	resp, err := client.Do(req)
 	if err != nil {
 		logger.Infof("HTTP GET error on %s: %s\n", url, err)
 		return


### PR DESCRIPTION
I was finding some domains would hang and get a false positive response from CloudFront. Adding an Accept header to the request fixes the issue. 

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
